### PR TITLE
[FIXED JENKINS-23364] make plugin available with goal prefix "jenkins-dev"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,6 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <goalPrefix>hudson-dev</goalPrefix>
-        </configuration>
       </plugin>
       <!-- not sure what these sites do but we don't have that site-component.xml
       <plugin>


### PR DESCRIPTION
The goals in _maven-jenkins-dev-plugin_ are available as e.g. `mvn hudson-dev:run` out of the box while using `mvn jenkins-dev:run` requires users to configure _org.jenkins-ci.tools_ as a _pluginGroup_ in maven's _settings.xml_.

This is not obvious (after all, it's the **jenkins-dev**-plugin) and no longer appropriate.

This PR removes the explicitely configured _goalPrefix_ of _hudson-dev_ so that the automatically assigned prefix of _jenkins-dev_ becomes available.

There is one drawback, though: the goals will no longer work with the legacy prefix of _hudson-dev_.
IMHO, this is acceptable.

See https://issues.jenkins-ci.org/browse/JENKINS-23364
